### PR TITLE
Fix segmentation fault in group_by and add escape characters to the filepattern

### DIFF
--- a/src/filepattern/cpp/internal/internal_pattern.cpp
+++ b/src/filepattern/cpp/internal/internal_pattern.cpp
@@ -155,20 +155,15 @@ void InternalPattern::getMatchingHelper(const tuple<string, vector<Types>>& vari
         this->getMatchingLoop(this->valid_files_, variable, values, temp);
     } else { // iterate files that matched previous call
         iter = this->matching_;
-        this->matching_.clear();
+        this->matching_.erase(this->matching_.begin(), this->matching_.end());
         this->getMatchingLoop(iter, variable, values, temp);
     }
 }
 
 vector<Tuple> InternalPattern::getMatching(const vector<tuple<string, vector<Types>>>& variables){
 
-    // return empty vector if no files matched pattern
-    if (this->valid_files_.size() == 0) {
-        vector<Tuple> empty;
-        return empty;
-    }
-
-    this->matching_.clear();
+    // clear the vector that stores matching files 
+    this->matching_.erase(this->matching_.begin(), this->matching_.end());
 
     // match files for each argument
     for(const auto& variableMap: variables){

--- a/src/filepattern/cpp/internal/internal_pattern.cpp
+++ b/src/filepattern/cpp/internal/internal_pattern.cpp
@@ -64,6 +64,11 @@ void InternalPattern::groupByHelper(const vector<string>& groups){
 
 
 void InternalPattern::groupBy(vector<string>& groups) {    
+
+    // Cannot group empty files so return
+    if (valid_files_.size() == 0) return;
+
+
     vector<std::pair<std::string, Types>> grouped_variables;
     this->setGroup(groups);
     this->valid_grouped_files_.clear();
@@ -83,6 +88,7 @@ void InternalPattern::groupBy(vector<string>& groups) {
     });
 
     Types current_value = get<0>(this->valid_files_[0])[group_by]; // get the value of variable
+
     vector<Tuple> empty_vec;
     int i = 0;
     int group_ptr = 0;
@@ -111,7 +117,7 @@ void InternalPattern::groupBy(vector<string>& groups) {
 
     groups.erase(groups.begin());
     this->groupByHelper(groups);
-    
+
 }
 
 std::vector<Tuple> InternalPattern::getMatchingBlock() {
@@ -155,6 +161,12 @@ void InternalPattern::getMatchingHelper(const tuple<string, vector<Types>>& vari
 }
 
 vector<Tuple> InternalPattern::getMatching(const vector<tuple<string, vector<Types>>>& variables){
+
+    // return empty vector if no files matched pattern
+    if (this->valid_files_.size() == 0) {
+        vector<Tuple> empty;
+        return empty;
+    }
 
     this->matching_.clear();
 

--- a/src/filepattern/cpp/pattern.cpp
+++ b/src/filepattern/cpp/pattern.cpp
@@ -50,8 +50,6 @@ void Pattern::filePatternToRegex(){
 
     replace(path_.begin(), path_.end(), '\\', '/');
 
-    replace(file_pattern_.begin(), file_pattern_.end(), '\\', '/');
-
     tuple vars = getRegex(this->file_pattern_, this->suppress_warnings_);
         
     this->regex_file_pattern_ = get<0>(vars);

--- a/src/filepattern/filepattern.py
+++ b/src/filepattern/filepattern.py
@@ -145,18 +145,22 @@ class PatternObject:
         Args:
             group_by: A string consisting of a single variable or a list of variables to group filenames by.
         """
-        
+
         if (group_by == []):
             group_by = ['*__all__*']
-        
+
         if (isinstance(group_by, str)):
                 group_by = [group_by]
+
         self._file_pattern.setGroup(group_by)
+
         if self._block_size == "":  
+
             if len(group_by) == 0 or group_by[0] != "":
                 self._file_pattern.groupBy(group_by)
+
             return self
-        
+
         if len(group_by) == 0 or (group_by != [""] and len(group_by) != 1):
             self._file_pattern.setGroup(group_by)
 
@@ -266,7 +270,6 @@ class FilePattern(PatternObject):
             suppress_warnings: True to suppress warning printed to console. Defaults to False.
         """
 
-       
         path = str(path) # change path type to string to support pathlib paths
         
         self._file_pattern = backend.FilePattern(path, pattern, block_size, recursive, suppress_warnings)

--- a/tests/test_filepattern.py
+++ b/tests/test_filepattern.py
@@ -61,6 +61,19 @@ class TestFilePattern():
                 assert fp_data.test_fp[i][0]["r"] == result[i][0]["r"] 
                 assert fp_data.test_fp[i][0]["c"] == result[i][0]["c"]
                 assert os.path.basename(fp_data.test_fp[i][1][0]) == os.path.basename(result[i][1][0])
+                
+    def test_get_matching_empty(self):
+        
+        pattern = 'wrong_pattern'
+         
+        nums = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        files = fp.FilePattern(self.path, pattern)
+
+        result = files.get_matching(r=[nums[0]])
+        
+        assert result == []
+        
 
     def test_get_matching_no_list(self):
          for pattern in self.patterns:
@@ -121,6 +134,21 @@ class TestFilePattern():
                     assert fp_data.fp_groupby[i][1][j][0]["r"] == result[i][1][j][0]["r"] 
                     assert fp_data.fp_groupby[i][1][j][0]["c"] == result[i][1][j][0]["c"]
                     assert os.path.basename(fp_data.fp_groupby[i][1][j][1][0]) == os.path.basename(result[i][1][j][1][0])
+                    
+    def test_group_by_empty(self):
+        
+        pattern = 'wrong_pattern'
+
+        files = fp.FilePattern(self.path, pattern)
+
+        result = []
+
+        for file in files(group_by="r"):
+            result.append(file)
+            
+        assert result == []
+
+        
         
     def test_group_by_all(self):
         for pattern in self.patterns:

--- a/tests/test_filepattern.py
+++ b/tests/test_filepattern.py
@@ -64,7 +64,7 @@ class TestFilePattern():
                 
     def test_get_matching_empty(self):
         
-        pattern = 'wrong_pattern'
+        pattern = 'wrong_pattern{r:d}.file'
          
         nums = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
@@ -137,7 +137,7 @@ class TestFilePattern():
                     
     def test_group_by_empty(self):
         
-        pattern = 'wrong_pattern'
+        pattern = 'wrong_pattern{r:d}.file'
 
         files = fp.FilePattern(self.path, pattern)
 


### PR DESCRIPTION
- Fix segmentation fault occurring in issue #19 when no files are found matching the filepattern
- Add escape characters to filepattern to allow for special regex characters to be escaped
- Add unit tests to prevent the group_by segmentation fault from occurring again